### PR TITLE
Fix event parsing in Lambda handler

### DIFF
--- a/english-conversation-service/README.md
+++ b/english-conversation-service/README.md
@@ -21,4 +21,5 @@ You can invoke the endpoint with a JSON payload:
 ```json
 {"message": "How are you?"}
 ```
-which returns a JSON response with ChatGPT's reply.
+which returns a JSON response with ChatGPT's reply. When using API Gateway,
+send this JSON as the request body so the Lambda function can parse it.

--- a/english-conversation-service/lambda_function.py
+++ b/english-conversation-service/lambda_function.py
@@ -7,7 +7,15 @@ openai.api_key = os.environ.get('OPENAI_API_KEY')
 
 
 def lambda_handler(event, context):
-    user_message = event.get('message', 'Hello')
+    """Handle Lambda invocation for a simple English chat API."""
+    payload = event
+    if isinstance(event, dict) and 'body' in event:
+        try:
+            payload = json.loads(event['body'] or '{}')
+        except json.JSONDecodeError:
+            payload = {}
+
+    user_message = payload.get('message', 'Hello')
     response = openai.ChatCompletion.create(
         model="gpt-3.5-turbo",
         messages=[{"role": "user", "content": user_message}],
@@ -17,3 +25,4 @@ def lambda_handler(event, context):
         'statusCode': 200,
         'body': json.dumps({'reply': reply})
     }
+

--- a/english-conversation-service/lambda_function.py
+++ b/english-conversation-service/lambda_function.py
@@ -12,7 +12,8 @@ def lambda_handler(event, context):
     if isinstance(event, dict) and 'body' in event:
         try:
             payload = json.loads(event['body'] or '{}')
-        except json.JSONDecodeError:
+        except json.JSONDecodeError as e:
+            logging.error(f"JSONDecodeError: {e}. Invalid JSON: {event['body']}")
             payload = {}
 
     user_message = payload.get('message', 'Hello')


### PR DESCRIPTION
## Summary
- handle API Gateway events that pass JSON in `body`
- document that payload should be sent in request body

## Testing
- `python -m py_compile english-conversation-service/lambda_function.py`
- `pip install -r english-conversation-service/requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685ac46e80dc8322bcd695b0da0827a1